### PR TITLE
Add ISO batch dumping console tool

### DIFF
--- a/IsoBatchDumper/IsoBatchDumper.csproj
+++ b/IsoBatchDumper/IsoBatchDumper.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\\Ps3DiscDumper\\Ps3DiscDumper.csproj" />
+  </ItemGroup>
+</Project>

--- a/IsoBatchDumper/Program.cs
+++ b/IsoBatchDumper/Program.cs
@@ -1,0 +1,96 @@
+using System.Diagnostics;
+using System.Threading;
+using Ps3DiscDumper;
+using WmiLight;
+
+if (args.Length < 2)
+{
+    Console.WriteLine("Usage: <iso-source-directory> <output-directory>");
+    return;
+}
+
+var sourceDir = args[0];
+var outputRoot = args[1];
+if (!Directory.Exists(sourceDir))
+{
+    Console.Error.WriteLine($"Source directory '{sourceDir}' does not exist.");
+    return;
+}
+Directory.CreateDirectory(outputRoot);
+
+var mounted = new List<string>();
+try
+{
+    foreach (var isoPath in Directory.EnumerateFiles(sourceDir, "*.iso"))
+    {
+        var before = EnumerateDrives();
+        using (var mountProc = Process.Start("powershell", $"Mount-DiskImage -ImagePath \"{isoPath}\""))
+            mountProc?.WaitForExit();
+        var newDrive = WaitForDrive(before);
+        if (newDrive is null)
+        {
+            Console.Error.WriteLine($"Failed to find mounted drive for {isoPath}");
+            continue;
+        }
+        mounted.Add(isoPath);
+        var (deviceId, driveLetter) = newDrive.Value;
+        Console.WriteLine($"Mounted {isoPath} as {deviceId} ({driveLetter})");
+        var output = Path.Combine(outputRoot, Path.GetFileNameWithoutExtension(isoPath));
+        try
+        {
+            using var dumper = new Dumper();
+            dumper.DetectDisc(driveLetter + Path.DirectorySeparatorChar);
+            await dumper.DumpAsync(output).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Error dumping {isoPath}: {ex.Message}");
+        }
+        finally
+        {
+            using (var dismountProc = Process.Start("powershell", $"Dismount-DiskImage -ImagePath \"{isoPath}\""))
+                dismountProc?.WaitForExit();
+            mounted.Remove(isoPath);
+        }
+    }
+}
+finally
+{
+    foreach (var isoPath in mounted)
+    {
+        try
+        {
+            using var dismountProc = Process.Start("powershell", $"Dismount-DiskImage -ImagePath \"{isoPath}\"");
+            dismountProc?.WaitForExit();
+        }
+        catch { }
+    }
+}
+
+static Dictionary<string, string?> EnumerateDrives()
+{
+    var result = new Dictionary<string, string?>();
+    using var wmi = new WmiConnection();
+    var drives = wmi.CreateQuery("SELECT * FROM Win32_CDROMDrive");
+    foreach (var drive in drives)
+    {
+        var lun = drive["SCSILogicalUnit"]?.ToString();
+        if (lun is null) continue;
+        var device = $"\\\\.\\CDROM{lun}";
+        result[device] = drive["Drive"] as string;
+    }
+    return result;
+}
+
+static (string DeviceId, string DriveLetter)? WaitForDrive(Dictionary<string, string?> before)
+{
+    for (var i = 0; i < 10; i++)
+    {
+        Thread.Sleep(500);
+        var after = EnumerateDrives();
+        var newDrive = after.FirstOrDefault(kv => !before.ContainsKey(kv.Key) && !string.IsNullOrEmpty(kv.Value));
+        if (!string.IsNullOrEmpty(newDrive.Key) && !string.IsNullOrEmpty(newDrive.Value))
+            return (newDrive.Key, newDrive.Value!);
+    }
+    return null;
+}

--- a/Ps3DiscDumper.sln
+++ b/Ps3DiscDumper.sln
@@ -19,6 +19,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Deploy", "Deploy", "{BA0C92
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UI.Avalonia", "UI.Avalonia\UI.Avalonia.csproj", "{EBFEB92B-CF70-48C2-B1B4-80CC21EFA072}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IsoBatchDumper", "IsoBatchDumper\\IsoBatchDumper.csproj", "{9ED38331-77B5-4711-B63C-11A238A38E73}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -56,12 +58,20 @@ Global
 		{EBFEB92B-CF70-48C2-B1B4-80CC21EFA072}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EBFEB92B-CF70-48C2-B1B4-80CC21EFA072}.Release|Any CPU.Build.0 = Release|Any CPU
 		{EBFEB92B-CF70-48C2-B1B4-80CC21EFA072}.Linux|Any CPU.ActiveCfg = Linux|Any CPU
-		{EBFEB92B-CF70-48C2-B1B4-80CC21EFA072}.Linux|Any CPU.Build.0 = Linux|Any CPU
-		{EBFEB92B-CF70-48C2-B1B4-80CC21EFA072}.MacOS|Any CPU.ActiveCfg = MacOS|Any CPU
-		{EBFEB92B-CF70-48C2-B1B4-80CC21EFA072}.MacOS|Any CPU.Build.0 = MacOS|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
+                {EBFEB92B-CF70-48C2-B1B4-80CC21EFA072}.Linux|Any CPU.Build.0 = Linux|Any CPU
+                {EBFEB92B-CF70-48C2-B1B4-80CC21EFA072}.MacOS|Any CPU.ActiveCfg = MacOS|Any CPU
+                {EBFEB92B-CF70-48C2-B1B4-80CC21EFA072}.MacOS|Any CPU.Build.0 = MacOS|Any CPU
+                {9ED38331-77B5-4711-B63C-11A238A38E73}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {9ED38331-77B5-4711-B63C-11A238A38E73}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {9ED38331-77B5-4711-B63C-11A238A38E73}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {9ED38331-77B5-4711-B63C-11A238A38E73}.Release|Any CPU.Build.0 = Release|Any CPU
+                {9ED38331-77B5-4711-B63C-11A238A38E73}.Linux|Any CPU.ActiveCfg = Release|Any CPU
+                {9ED38331-77B5-4711-B63C-11A238A38E73}.Linux|Any CPU.Build.0 = Release|Any CPU
+                {9ED38331-77B5-4711-B63C-11A238A38E73}.MacOS|Any CPU.ActiveCfg = Release|Any CPU
+                {9ED38331-77B5-4711-B63C-11A238A38E73}.MacOS|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
+        GlobalSection(SolutionProperties) = preSolution
+                HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0472A22B-358A-4484-B2BC-E7536BC2CD44}


### PR DESCRIPTION
## Summary
- add `IsoBatchDumper` console app targeting net9.0 that mounts ISO images, finds the assigned `\\.\CDROM#` device and runs `Ps3DiscDumper` for each
- ensure mounted images are dismounted even on errors and integrate the project into the solution

## Testing
- `dotnet build Ps3DiscDumper.sln` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_689d26ef65c883318e8091bf181428d1