### PR TITLE
Add dry run option to ISO batch dumper

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,13 @@ Building
 * It is recommended to use [JetBrains Raider](https://www.jetbrains.com/rider/), [Visual Studio](https://visualstudio.microsoft.com/), or [VS Code](https://code.visualstudio.com/) for development.
   * On Linux select the Linux configuration to prevent various issues due to Windows-specific dependencies.
   * You can build for both Windows and Linux on Windows (you can test Linux build with WSL2 or with a Linux VM).
+
+Iso Batch Dumper
+================
+`IsoBatchDumper` can process multiple ISO images in a directory. It runs on Windows and mounts each image before invoking the dumper.
+
+```
+IsoBatchDumper <iso-source-directory> <output-directory> [--dry-run]
+```
+
+Use `--dry-run` to print planned operations without mounting or dumping the images.


### PR DESCRIPTION
## Summary
- allow IsoBatchDumper to accept a `--dry-run`/`-n` option
- document batch ISO dumping usage and dry-run flag

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_689d297eaba88331aba99bc5ffb7f697