### PR TITLE
Initialize dumper in batch utility before dumping

### DIFF
--- a/IsoBatchDumper/Program.cs
+++ b/IsoBatchDumper/Program.cs
@@ -78,6 +78,8 @@ try
         {
             using var dumper = new Dumper();
             dumper.DetectDisc(driveLetter + Path.DirectorySeparatorChar);
+            await dumper.FindDiscKeyAsync(SettingsProvider.Settings.IrdDir)
+                .ConfigureAwait(false);
             await dumper.DumpAsync(output).ConfigureAwait(false);
         }
         catch (Exception ex)


### PR DESCRIPTION
## Summary
- ensure batch ISO dumper resolves disc keys and opens drive before dumping

## Testing
- `dotnet test` *(fails: Failed to make API call to IRD Library)*

------
https://chatgpt.com/codex/tasks/task_e_689d34ceff608331ae0423e86e56d773